### PR TITLE
#1 editor rulers color changed

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -117,7 +117,7 @@ const uiColors = {
     activeForeground: tokens.grays[400]
   },
   editorRuler: {
-    foreground: tokens.white
+    foreground: tokens.grays[600]
   },
   editorMarkerNavigation: {
     background: tokens.grays[700]


### PR DESCRIPTION
According to: https://github.com/siddharthkp/codesandbox-black-vscode-theme/issues/1 editor rulers was changed to `tokens.grays[600]`